### PR TITLE
chore: re-license code as MIT OR Apache2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 description = "dbc parser"
 readme = "README.md"
 repository = "https://github.com/MDGSF/rdbc"
-license-file = "LICENSE"
+license = "MIT OR Apache-2.0"
 keywords = ["dbc", "parser", "format"]
 
 [lib]

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -174,28 +174,3 @@ TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
    of your accepting any such warranty or additional liability.
 
 END OF TERMS AND CONDITIONS
-
-APPENDIX: How to apply the Apache License to your work.
-
-   To apply the Apache License to your work, attach the following
-   boilerplate notice, with the fields enclosed by brackets "[]"
-   replaced with your own identifying information. (Don't include
-   the brackets!)  The text should be enclosed in the appropriate
-   comment syntax for the file format. We also recommend that a
-   file or class name and description of purpose be included on the
-   same "printed page" as the copyright notice for easier
-   identification within third-party archives.
-
-Copyright [yyyy] [name of copyright owner]
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,7 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Ashcon Mohseninia
-Copyright (c) 2023-2025 Yuri Astrakhan <YuriAstrakhan@gmail.com>
+Copyright (c) 2024 Huang Jian
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Please consider re-licensing this code as `MIT OR Apache2`. This is a common pattern with most of Rust code.

Thank you!

cc: @MDGSF @huangjian
