### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/oxibus/rrdbc/compare/v0.2.0...v0.2.1) - 2025-10-08
+
+### Added
+
+- use shared test files and update snapshots ([#17](https://github.com/oxibus/rrdbc/pull/17))
+- add `decode_cp1252` and snapshot tests ([#16](https://github.com/oxibus/rrdbc/pull/16))
+
 ## [0.2.0](https://github.com/oxibus/rrdbc/compare/v0.1.0...v0.2.0) - 2025-10-03
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rrdbc"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["MDGSF"]
 edition = "2021"
 description = "dbc parser"


### PR DESCRIPTION



## 🤖 New release

* `rrdbc`: 0.2.0 -> 0.2.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.1](https://github.com/oxibus/rrdbc/compare/v0.2.0...v0.2.1) - 2025-10-08

### Added

- use shared test files and update snapshots ([#17](https://github.com/oxibus/rrdbc/pull/17))
- add `decode_cp1252` and snapshot tests ([#16](https://github.com/oxibus/rrdbc/pull/16))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).